### PR TITLE
Add dependencies to oscillator_gen readme

### DIFF
--- a/Project 1/oscillator_gen/README.md
+++ b/Project 1/oscillator_gen/README.md
@@ -2,3 +2,6 @@
 1. Open directory in command line.
 2. run the command: `make run`
 3. Generated cir files will be created in the `oscillator_gen` directory.
+
+## Dependencies
+In order to compile and build the program, ensure you have both `make` and `clang++` present on the system.


### PR DESCRIPTION
The readme should detail what programs are required in order to successfully compile the program.